### PR TITLE
Begin rolling fixture

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+serde_json = "*"

--- a/src/main.rs
+++ b/src/main.rs
@@ -172,6 +172,7 @@ fn log_raw_output(commandhelp_logs: &Path, command: String, raw_command_help: St
 // use regex::Regex;
 #[cfg(test)]
 mod test {
+    #[allow(unused_imports)]
     use super::*;
     use std::collections::HashMap;
     fn fake_parse_getinfo() -> HashMap<&'static str, &'static str> {
@@ -202,6 +203,7 @@ mod test {
         use serde_json::Value;
         use std::collections::HashSet;
         use std::process::Command;
+        #[allow(dead_code)]
         struct GetInfoResponseFixture {
             repr_bytes: Vec<u8>,
             repr_string: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -199,11 +199,58 @@ mod test {
     }
     mod getinfo {
         use super::*;
+        use serde_json::Value;
+        use std::collections::HashSet;
+        use std::process::Command;
+        struct GetInfoResponseFixture {
+            repr_bytes: Vec<u8>,
+            repr_string: String,
+            repr_json: Value,
+            repr_keyset: HashSet<String>,
+        }
+        impl GetInfoResponseFixture {
+            fn new() -> GetInfoResponseFixture {
+                let repr_bytes = Command::new("zcash-cli")
+                    .arg("getinfo")
+                    .output()
+                    .unwrap()
+                    .stdout;
+                let repr_string = String::from_utf8(repr_bytes.clone()).unwrap();
+                let repr_json = serde_json::de::from_str(&repr_string).unwrap();
+                let repr_keyset;
+                if let Value::Object(objmap) = &repr_json {
+                    repr_keyset = objmap.keys().cloned().collect();
+                } else {
+                    panic!()
+                }
+                GetInfoResponseFixture {
+                    repr_bytes,
+                    repr_string,
+                    repr_json,
+                    repr_keyset,
+                }
+            }
+        }
         #[test]
         fn concrete_annotation_match() {
             let static_test_annotation = fake_parse_getinfo();
             let eventually_real = fake_parse_getinfo();
             assert_eq!(static_test_annotation, eventually_real);
+        }
+        #[test]
+        fn validate_response_as_subset() {
+            let response_fixture = GetInfoResponseFixture::new();
+            let testdata_keys: HashSet<String> = fake_parse_getinfo()
+                .keys()
+                .map(|&x| x.to_string())
+                .collect();
+            dbg!(&response_fixture.repr_keyset.difference(&testdata_keys));
+            assert!(response_fixture
+                .repr_keyset
+                .difference(&testdata_keys)
+                .cloned()
+                .collect::<String>()
+                .is_empty());
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -232,12 +232,14 @@ mod test {
             }
         }
         #[test]
+        #[ignore = "not yet implemented"]
         fn concrete_annotation_match() {
             let static_test_annotation = fake_parse_getinfo();
             let eventually_real = fake_parse_getinfo();
             assert_eq!(static_test_annotation, eventually_real);
         }
         #[test]
+        #[ignore = "zcash-cli help validation test"]
         fn validate_response_as_subset() {
             let response_fixture = GetInfoResponseFixture::new();
             let testdata_keys: HashSet<String> = fake_parse_getinfo()


### PR DESCRIPTION
This code separates out common environment concerns from the specifics of an individual test.   The new test fails due to a bug in the RPC docs (noticed by @AloeareV).  

With a little abstraction we'll be able to apply this kind of test to ALL RPCs that return a key-map response and take no input parameters.

It should now be relatively straightforward to produce a set of tests for different aspects of getinfo (and getinfo-like RPCs).

It's noteworthy testing that the parser is correct for the case of getinfo, is a different _kind_ of test to validating that the documentation is correct.

With the addition of `validate_response_as_subset` we now have one test in each category!