### PR TITLE
WIP: parse_getinfo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "quizface"
 version = "0.1.0"
-authors = ["ha"]
+authors = ["zingolabs"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -7,9 +7,9 @@ pub(crate) fn name_logdirs() -> (String, String) {
         qfver = QUIZFACE_VERSION
     );
     let mut master_name = log_parent_template.clone();
-    master_name.push_str("masterhelp_output/raw");
+    master_name.push_str("masterhelp_output/raw/");
     let mut base_name = log_parent_template.clone();
-    base_name.push_str("help_output/raw");
+    base_name.push_str("help_output/raw/");
     (master_name, base_name)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,7 +195,8 @@ fn parse_raw_output(
         };
         //dbg!(&unparsed_key_str);
 
-        let unparsed_key_str_vec: Vec<&str> = unparsed_key_str.split('"').collect();
+        let unparsed_key_str_vec: Vec<&str> =
+            unparsed_key_str.split('"').collect();
 
         // unparsed_key_str_vec should still contain leading "" element
         // and trailing ":" element, and be exactly 3 elements in length
@@ -227,7 +228,8 @@ fn parse_raw_output(
         // these 'keywords' within first set of paranthesis.
 
         // split with an closure to support multiple 'splitters'
-        let unparsed_value_str_vec: Vec<&str> = line.split(|c| c == '(' || c == ')').collect();
+        let unparsed_value_str_vec: Vec<&str> =
+            line.split(|c| c == '(' || c == ')').collect();
 
         // because unparsed_value_str_vec will have an element before
         // the first '(', and there may be more sets of parenthesis,


### PR DESCRIPTION
WIP. in addition to commit string "rename variables, comment cleanup" I also 'fixed' the naming of files that were being prepended by 'raw' and placed alongside the `raw` directory.

The first pass of parsing will be to properly parse the `getinfo` command. This may cause difficulties including the parse helper function in the `for` loop, now in the `main` function.

More commits to follow.