### PR TITLE
add expect_panic tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,4 +206,46 @@ mod unit {
             parse_raw_output(test::EXTRABRACKETS2_HELP_GETINFO.to_string());
         assert_eq!(valid_help_in, test::valid_getinfo_annotation());
     }
+    #[test]
+    #[should_panic]
+    fn parse_raw_output_more_than_one_set_of_brackets_input() {
+        let valid_help_in =
+            parse_raw_output(test::MORE_BRACKET_PAIRS_HELP_GETINFO.to_string());
+        assert_eq!(valid_help_in, test::valid_getinfo_annotation());
+    }
+    #[test]
+    #[should_panic]
+    fn parse_raw_output_two_starting_brackets_input() {
+        let valid_help_in =
+            parse_raw_output(test::EXTRA_START_BRACKET_HELP_GETINFO.to_string());
+        assert_eq!(valid_help_in, test::valid_getinfo_annotation());
+    }
+    #[test]
+    #[should_panic]
+    fn parse_raw_output_two_ending_brackets_input() {
+        let valid_help_in =
+            parse_raw_output(test::EXTRA_END_BRACKET_HELP_GETINFO.to_string());
+        assert_eq!(valid_help_in, test::valid_getinfo_annotation());
+    }
+    #[test]
+    #[should_panic]
+    fn parse_raw_output_no_results_input() {
+        let valid_help_in =
+            parse_raw_output(test::NO_RESULT_HELP_GETINFO.to_string());
+        assert_eq!(valid_help_in, test::valid_getinfo_annotation());
+    }
+    #[test]
+    #[should_panic]
+    fn parse_raw_output_no_end_bracket_input() {
+        let valid_help_in =
+            parse_raw_output(test::NO_END_BRACKET_HELP_GETINFO.to_string());
+        assert_eq!(valid_help_in, test::valid_getinfo_annotation());
+    }
+    #[test]
+    #[should_panic]
+    fn parse_raw_output_no_start_bracket_input() {
+        let valid_help_in =
+            parse_raw_output(test::NO_START_BRACKET_HELP_GETINFO.to_string());
+        assert_eq!(valid_help_in, test::valid_getinfo_annotation());
+    }
 }

--- a/src/utils/test.rs
+++ b/src/utils/test.rs
@@ -158,6 +158,147 @@ Result:
 }
 "#;
 
+pub const MORE_BRACKET_PAIRS_HELP_GETINFO: &str = r#"
+getinfo with two sets of curly brackets
+Result:
+{
+  "version": xxxxx,           (numeric) the server version
+  "protocolversion": xxxxx,   (numeric) the protocol version
+  "walletversion": xxxxx,     (numeric) the wallet version
+  "balance": xxxxxxx,         (numeric) the total Zcash balance of the wallet
+  "blocks": xxxxxx,           (numeric) the current number of blocks processed in the server
+  "timeoffset": xxxxx,        (numeric) the time offset (deprecated; always 0)
+}
+{
+  "connections": xxxxx,       (numeric) the number of connections
+  "proxy": "host:port",     (string, optional) the proxy used by the server
+  "difficulty": xxxxxx,       (numeric) the current difficulty
+  "testnet": true|false,      (boolean) if the server is using testnet or not
+  "keypoololdest": xxxxxx,    (numeric) the timestamp (seconds since GMT epoch) of the oldest pre-generated key in the key pool
+  "keypoolsize": xxxx,        (numeric) how many new keys are pre-generated
+  "unlocked_until": ttt,      (numeric) the timestamp in seconds since epoch (midnight Jan 1 1970 GMT) that the wallet is unlocked for transfers, or 0 if the wallet is locked
+  "paytxfee": x.xxxx,         (numeric) the transaction fee set in ZEC/kB
+  "relayfee": x.xxxx,         (numeric) minimum relay fee for non-free transactions in ZEC/kB
+  "errors": "..."           (string) any error messages
+}
+"#;
+
+pub const EXTRA_START_BRACKET_HELP_GETINFO: &str = r#"
+getinfo with two sets of curly brackets
+Result:
+{
+  "version": xxxxx,           (numeric) the server version
+  "protocolversion": xxxxx,   (numeric) the protocol version
+  "walletversion": xxxxx,     (numeric) the wallet version
+  "balance": xxxxxxx,         (numeric) the total Zcash balance of the wallet
+  "blocks": xxxxxx,           (numeric) the current number of blocks processed in the server
+  "timeoffset": xxxxx,        (numeric) the time offset (deprecated; always 0)
+{
+  "connections": xxxxx,       (numeric) the number of connections
+  "proxy": "host:port",     (string, optional) the proxy used by the server
+  "difficulty": xxxxxx,       (numeric) the current difficulty
+  "testnet": true|false,      (boolean) if the server is using testnet or not
+  "keypoololdest": xxxxxx,    (numeric) the timestamp (seconds since GMT epoch) of the oldest pre-generated key in the key pool
+  "keypoolsize": xxxx,        (numeric) how many new keys are pre-generated
+  "unlocked_until": ttt,      (numeric) the timestamp in seconds since epoch (midnight Jan 1 1970 GMT) that the wallet is unlocked for transfers, or 0 if the wallet is locked
+  "paytxfee": x.xxxx,         (numeric) the transaction fee set in ZEC/kB
+  "relayfee": x.xxxx,         (numeric) minimum relay fee for non-free transactions in ZEC/kB
+  "errors": "..."           (string) any error messages
+}
+"#;
+
+pub const EXTRA_END_BRACKET_HELP_GETINFO: &str = r#"
+getinfo with two sets of curly brackets
+Result:
+{
+  "version": xxxxx,           (numeric) the server version
+  "protocolversion": xxxxx,   (numeric) the protocol version
+  "walletversion": xxxxx,     (numeric) the wallet version
+  "balance": xxxxxxx,         (numeric) the total Zcash balance of the wallet
+  "blocks": xxxxxx,           (numeric) the current number of blocks processed in the server
+  "timeoffset": xxxxx,        (numeric) the time offset (deprecated; always 0)
+}
+  "connections": xxxxx,       (numeric) the number of connections
+  "proxy": "host:port",     (string, optional) the proxy used by the server
+  "difficulty": xxxxxx,       (numeric) the current difficulty
+  "testnet": true|false,      (boolean) if the server is using testnet or not
+  "keypoololdest": xxxxxx,    (numeric) the timestamp (seconds since GMT epoch) of the oldest pre-generated key in the key pool
+  "keypoolsize": xxxx,        (numeric) how many new keys are pre-generated
+  "unlocked_until": ttt,      (numeric) the timestamp in seconds since epoch (midnight Jan 1 1970 GMT) that the wallet is unlocked for transfers, or 0 if the wallet is locked
+  "paytxfee": x.xxxx,         (numeric) the transaction fee set in ZEC/kB
+  "relayfee": x.xxxx,         (numeric) minimum relay fee for non-free transactions in ZEC/kB
+  "errors": "..."           (string) any error messages
+}
+"#;
+
+pub const NO_RESULT_HELP_GETINFO: &str = r#"
+getinfo with no Result:
+
+{
+  "version": xxxxx,           (numeric) the server version
+  "protocolversion": xxxxx,   (numeric) the protocol version
+  "walletversion": xxxxx,     (numeric) the wallet version
+  "balance": xxxxxxx,         (numeric) the total Zcash balance of the wallet
+  "blocks": xxxxxx,           (numeric) the current number of blocks processed in the server
+  "timeoffset": xxxxx,        (numeric) the time offset (deprecated; always 0)
+  "connections": xxxxx,       (numeric) the number of connections
+  "proxy": "host:port",     (string, optional) the proxy used by the server
+  "difficulty": xxxxxx,       (numeric) the current difficulty
+  "testnet": true|false,      (boolean) if the server is using testnet or not
+  "keypoololdest": xxxxxx,    (numeric) the timestamp (seconds since GMT epoch) of the oldest pre-generated key in the key pool
+  "keypoolsize": xxxx,        (numeric) how many new keys are pre-generated
+  "unlocked_until": ttt,      (numeric) the timestamp in seconds since epoch (midnight Jan 1 1970 GMT) that the wallet is unlocked for transfers, or 0 if the wallet is locked
+  "paytxfee": x.xxxx,         (numeric) the transaction fee set in ZEC/kB
+  "relayfee": x.xxxx,         (numeric) minimum relay fee for non-free transactions in ZEC/kB
+  "errors": "..."           (string) any error messages
+}
+"#;
+pub const NO_END_BRACKET_HELP_GETINFO: &str = r#"
+getinfo with no closing bracket
+Result:
+{
+  "version": xxxxx,           (numeric) the server version
+  "protocolversion": xxxxx,   (numeric) the protocol version
+  "walletversion": xxxxx,     (numeric) the wallet version
+  "balance": xxxxxxx,         (numeric) the total Zcash balance of the wallet
+  "blocks": xxxxxx,           (numeric) the current number of blocks processed in the server
+  "timeoffset": xxxxx,        (numeric) the time offset (deprecated; always 0)
+  "connections": xxxxx,       (numeric) the number of connections
+  "proxy": "host:port",     (string, optional) the proxy used by the server
+  "difficulty": xxxxxx,       (numeric) the current difficulty
+  "testnet": true|false,      (boolean) if the server is using testnet or not
+  "keypoololdest": xxxxxx,    (numeric) the timestamp (seconds since GMT epoch) of the oldest pre-generated key in the key pool
+  "keypoolsize": xxxx,        (numeric) how many new keys are pre-generated
+  "unlocked_until": ttt,      (numeric) the timestamp in seconds since epoch (midnight Jan 1 1970 GMT) that the wallet is unlocked for transfers, or 0 if the wallet is locked
+  "paytxfee": x.xxxx,         (numeric) the transaction fee set in ZEC/kB
+  "relayfee": x.xxxx,         (numeric) minimum relay fee for non-free transactions in ZEC/kB
+  "errors": "..."           (string) any error messages
+
+"#;
+
+pub const NO_START_BRACKET_HELP_GETINFO: &str = r#"
+getinfo with no beginning bracket
+Result:
+
+  "version": xxxxx,           (numeric) the server version
+  "protocolversion": xxxxx,   (numeric) the protocol version
+  "walletversion": xxxxx,     (numeric) the wallet version
+  "balance": xxxxxxx,         (numeric) the total Zcash balance of the wallet
+  "blocks": xxxxxx,           (numeric) the current number of blocks processed in the server
+  "timeoffset": xxxxx,        (numeric) the time offset (deprecated; always 0)
+  "connections": xxxxx,       (numeric) the number of connections
+  "proxy": "host:port",     (string, optional) the proxy used by the server
+  "difficulty": xxxxxx,       (numeric) the current difficulty
+  "testnet": true|false,      (boolean) if the server is using testnet or not
+  "keypoololdest": xxxxxx,    (numeric) the timestamp (seconds since GMT epoch) of the oldest pre-generated key in the key pool
+  "keypoolsize": xxxx,        (numeric) how many new keys are pre-generated
+  "unlocked_until": ttt,      (numeric) the timestamp in seconds since epoch (midnight Jan 1 1970 GMT) that the wallet is unlocked for transfers, or 0 if the wallet is locked
+  "paytxfee": x.xxxx,         (numeric) the transaction fee set in ZEC/kB
+  "relayfee": x.xxxx,         (numeric) minimum relay fee for non-free transactions in ZEC/kB
+  "errors": "..."           (string) any error messages
+}
+"#;
+
 pub fn valid_getinfo_annotation() -> HashMap<String, String> {
     [
         ("version", "Decimal"),


### PR DESCRIPTION
Building out more unit tests based around parse_raw_output.

This could be accepted as in, built out more, or used as a branch for expanding tests along more functions.