### PR TITLE
refactor logging functions and migrate to logging.rs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,6 @@
-use quizface::utils::logging;
-use std::path::Path;
+use quizface::utils::logging::log_raw_output;
 fn main() {
-    // TODO move all logging to lib.rs?
-    let (masterhelp_dir_name, commandhelp_dir_name) = logging::name_logdirs();
-
-    // ingest_commands() also logs the masterhelp.txt file
-    // from the same String from which commands are parsed
-    let commands = quizface::ingest_commands(Path::new(&masterhelp_dir_name));
+    let commands = quizface::ingest_commands();
 
     for command in commands {
         let command_help_output = quizface::get_command_help(&command);
@@ -15,16 +9,10 @@ fn main() {
         quizface::check_success(&command_help_output.status);
 
         let raw_command_help =
-            match std::string::String::from_utf8(command_help_output.stdout) {
-                Ok(x) => x,
-                Err(e) => panic!("Invalid, error: {}", e),
-            };
+            std::string::String::from_utf8(command_help_output.stdout)
+                .expect("Invalid raw_command_help, error!");
 
-        logging::log_raw_output(
-            Path::new(&commandhelp_dir_name),
-            command.clone(),
-            raw_command_help.clone(),
-        );
+        log_raw_output(command.clone(), raw_command_help.clone());
 
         // TODO : make more general and remove `if`
         if command == "getinfo".to_string() {
@@ -36,6 +24,3 @@ fn main() {
     }
     println!("main() complete!");
 }
-
-// next target
-// z_getnewaddress

--- a/src/utils/logging.rs
+++ b/src/utils/logging.rs
@@ -1,16 +1,24 @@
+use std::fs;
+use std::path::Path;
 const QUIZFACE_VERSION: &'static str = env!("CARGO_PKG_VERSION");
 
 pub fn name_logdirs() -> (String, String) {
-    let log_parent_template = format!(
+    let log_parent_template: String = format!(
         "./logs/{zdver}_{qfver}/",
         zdver = get_zcashd_version(),
         qfver = QUIZFACE_VERSION
     );
-    let mut master_name = log_parent_template.clone();
-    master_name.push_str("masterhelp_output/raw/");
-    let mut base_name = log_parent_template.clone();
-    base_name.push_str("help_output/raw/");
+    let master_name: String =
+        format!("{}masterhelp_output/raw/", log_parent_template);
+    let base_name: String = format!("{}help_output/raw/", log_parent_template);
     (master_name, base_name)
+}
+
+pub fn create_log_dirs() {
+    fs::create_dir_all(Path::new(&name_logdirs().0))
+        .expect("error crating master dir!");
+    fs::create_dir_all(Path::new(&name_logdirs().1))
+        .expect("error creating commands dir!");
 }
 
 fn get_zcashd_version() -> String {
@@ -30,15 +38,14 @@ fn get_zcashd_version() -> String {
         .to_string()
 }
 
-pub fn log_raw_output(
-    commandhelp_dir: &std::path::Path,
-    command: String,
-    raw_command_help: String,
-) {
-    use std::fs;
-    fs::create_dir_all(commandhelp_dir).expect("error creating commands dir!");
+pub fn log_masterhelp_output(raw_help: &str) {
+    fs::write(format!("{}masterhelp.txt", name_logdirs().0), raw_help)
+        .expect("panic during fs:write masterhelp!");
+}
+
+pub fn log_raw_output(command: String, raw_command_help: String) {
     fs::write(
-        format!("{}{}.txt", commandhelp_dir.to_str().unwrap(), &command),
+        format!("{}{}.txt", name_logdirs().1, &command),
         &raw_command_help,
     )
     .expect("panic during fs::write command help!");


### PR DESCRIPTION
A refactor of the logging code and migration of functionality to `/src/utils/logging.rs`

The functions run, and tests pass.

There could possibly be more improvements, feedback solicited. For example `log_masterhelp_output()` and `log_raw_output()` both perform very similar functions, and might be rolled together, or named more clearly.