### PR TITLE
unignore test, shows apparent bug in annotate_result

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -536,16 +536,13 @@ mod unit {
         assert_eq!(expected_result, annotated);
     }
 
-    // ------------------ annotate_result : ignored --------
-    // TODO special case : consolodate
-    #[ignore]
     #[test]
     fn annotate_result_special_nested_blockchaininfo() {
         let mut special_nested_blockchaininfo =
             &mut test::SPECIAL_NESTED_GETBLOCKCHAININFO.chars();
         let annotated = annotate_result(&mut special_nested_blockchaininfo);
-        let expected_result = test::SPECIAL_NESTED_GETBLOCKCHAININFO_RESULT;
-        assert_eq!(expected_result, annotated.to_string());
+        let expected_result = serde_json::json!({"xxxx":{"name":"String"}});
+        assert_eq!(expected_result, annotated);
     }
 
     // ----------------sanity_check---------------

--- a/src/utils/test.rs
+++ b/src/utils/test.rs
@@ -682,7 +682,7 @@ pub const SIMPLE_UNNESTED_GETBLOCKCHAININFO_RESULT: &str =
     r#"{"name":"String"}"#;
 
 pub const SPECIAL_NESTED_GETBLOCKCHAININFO: &str = r#"{ 
-     "xxxx" : {                (string) branch ID of the upgrade
+     "xxxx": {                (string) branch ID of the upgrade
         "name": "xxxx",        (string) name of upgrade
    }
 }


### PR DESCRIPTION
It seems to me that there's a bug in the output of `annotate_result`, it seems like `annotate_result` is stuffing a `\" ` onto the end of the ident that was derived from `xxxx`.

You can generate the interesting result by running:

`cargo test annotate_result_special_nested_blockchaininfo`