### PR TITLE
Unignore ihm elb input

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,32 +118,25 @@ fn annotate_object(result_chars: &mut std::str::Chars) -> serde_json::Value {
     loop {
         match result_chars.next().unwrap() {
             '}' => {
-                //dbg!("end brace");
-                //dbg!(&viewed);
                 if viewed.trim().is_empty() {
                     break;
                 }
                 if viewed.trim() == ", ..." {
-                    dbg!("trailing dots in Object");
                 }
                 let mut partial_ident_label_bindings =
                     bind_idents_labels(viewed.clone(), None);
                 viewed.clear();
-                //dbg!(&partial_ident_label_bindings);
                 // append works, but `.extend()` is more atomic, might
                 // be worth looking at for refinements.
                 ident_label_bindings.append(&mut partial_ident_label_bindings);
-                //dbg!(&ident_label_bindings);
                 break;
             }
             last_viewed if last_viewed == '[' || last_viewed == '{' => {
-                //dbg!("recursing");
                 let inner_value = match last_viewed {
                     '[' => annotate_array(result_chars),
                     '{' => annotate_object(result_chars),
                     _ => unreachable!("last_viewed is either '[' or '{'"),
                 };
-                //dbg!(&inner_value);
                 let mut partial_ident_label_bindings =
                     bind_idents_labels(viewed.clone(), Some(inner_value));
                 viewed.clear();
@@ -163,27 +156,18 @@ fn annotate_array(result_chars: &mut std::str::Chars) -> serde_json::Value {
     loop {
         match result_chars.next().unwrap() {
             ']' => {
-                dbg!("end square bracket! ']' ");
-                dbg!(&viewed);
                 if viewed.trim().is_empty() {
                     break;
                 }
-                if viewed.trim() == ", ..." {
-                    dbg!("trailing dots in Array");
-                }
-                dbg!(&viewed);
                 viewed.clear();
-                dbg!(&ordered_results);
                 break;
             }
             last_viewed if last_viewed == '[' || last_viewed == '{' => {
-                dbg!("recursing in annotate_array");
                 let inner_value = if last_viewed == '[' {
                     annotate_array(result_chars)
                 } else {
                     annotate_object(result_chars)
                 };
-                dbg!(&inner_value);
                 viewed.clear();
                 // TODO maybe temporary: to allow detection of `, ...`
                 ordered_results.push(inner_value)
@@ -205,8 +189,6 @@ fn bind_idents_labels(
     viewed: String,
     inner_value: Option<Value>,
 ) -> Map<String, Value> {
-    dbg!("bind_idents_labels called");
-    dbg!(&viewed);
     // let cleaned = clean_viewed(viewed);
     // TODO rename cleaned
     let mut viewed_lines = viewed
@@ -214,7 +196,6 @@ fn bind_idents_labels(
         .lines()
         .map(|line| line.to_string())
         .collect::<Vec<String>>();
-    dbg!(&viewed_lines);
     // ignoring the first line if it only whitespace or does not
     // contain a `:` char.
     if viewed_lines[0].trim().is_empty()
@@ -223,11 +204,9 @@ fn bind_idents_labels(
         viewed_lines.remove(0); //.trim();
     }
     //viewed_lines is now a Vec of strings that were lines in viewed.
-    dbg!(&inner_value);
     if inner_value != None {
         // possible if/let
         let mut viewed_lines_mutable = viewed_lines.clone();
-        dbg!(&viewed_lines_mutable);
         let last_ident_untrimmed = viewed_lines_mutable.pop().unwrap();
         let last_ident = last_ident_untrimmed
             .trim()
@@ -270,7 +249,6 @@ fn label_identifier(ident_with_metadata: String) -> (String, String) {
         .collect::<Vec<&str>>();
     let ident = ident_and_metadata[0].trim_matches('"');
     let meta_data = ident_and_metadata[1].trim();
-    //dbg!(&meta_data);
     let raw_label: &str = meta_data
         .split(|c| c == '(' || c == ')')
         .collect::<Vec<&str>>()[1];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ pub fn check_success(output: &std::process::ExitStatus) {
 }
 
 pub fn interpret_help_message(raw_command_help: &str) -> serde_json::Value {
-    let (cmd_name, result_data) = extract_name_and_result(raw_command_help);
+    let (_cmd_name, result_data) = extract_name_and_result(raw_command_help);
     let scrubbed_result = scrub_result(result_data);
     annotate_result(&mut scrubbed_result.chars())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -700,14 +700,21 @@ mod unit {
         );
     }
 
-    #[ignore]
     #[test]
     fn interpret_help_message_getblockchaininfo_enforce_and_reject_fragment() {
         let expected_incoming =
             test::GETBLOCKCHAININFO_ENFORCE_AND_REJECT_FRAGMENT;
-        let expected_results = r#"{"enforce":"{\"found\":\"Decimal\",\"required\":\"Decimal\",\"status\":\"bool\",\"window\":\"Decimal\"},","id":"String","reject":"{\"found\":\"Decimal\",\"required\":\"Decimal\",\"status\":\"bool\",\"window\":\"Decimal\"}","version":"Decimal"}"#;
-        let interpreted =
-            format!("{}", interpret_help_message(expected_incoming));
+        let expected_results = serde_json::json!({"enforce":{"found":"Decimal",
+                                                             "required":"Decimal",
+                                                             "status":"bool",
+                                                             "window":"Decimal"},
+                                                  "id":"String",
+                                                  "reject":{"found":"Decimal",
+                                                            "required":"Decimal",
+                                                            "status":"bool",
+                                                            "window":"Decimal"},
+                                                  "version":"Decimal"});
+        let interpreted = interpret_help_message(expected_incoming);
         assert_eq!(interpreted, expected_results);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,8 +121,6 @@ fn annotate_object(result_chars: &mut std::str::Chars) -> serde_json::Value {
                 if viewed.trim().is_empty() {
                     break;
                 }
-                if viewed.trim() == ", ..." {
-                }
                 let mut partial_ident_label_bindings =
                     bind_idents_labels(viewed.clone(), None);
                 viewed.clear();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -654,17 +654,14 @@ mod unit {
         dbg!(interpret_help_message(test::UPGRADES_IN_OBJ_EXTRACTED));
     }
 
-    // ----------------interpret_help_message : ignored---------------
+    // ----------------interpret_help_message---------------
 
-    // TODO look at these; retool or remove.
-    // test::valid_getinfo_annotation() is not correct.
     #[test]
     fn interpret_help_message_expected_input_valid() {
         let valid_help_in = interpret_help_message(test::HELP_GETINFO);
         assert_eq!(valid_help_in, test::valid_getinfo_annotation());
     }
 
-    #[ignore]
     #[test]
     fn interpret_help_message_early_lbracket_input() {
         let valid_help_in =
@@ -672,7 +669,6 @@ mod unit {
         assert_eq!(valid_help_in, test::valid_getinfo_annotation());
     }
 
-    #[ignore]
     #[test]
     fn interpret_help_message_early_rbracket_input() {
         let valid_help_in =
@@ -680,7 +676,6 @@ mod unit {
         assert_eq!(valid_help_in, test::valid_getinfo_annotation());
     }
 
-    #[ignore]
     #[test]
     fn interpret_help_message_early_extrabrackets_input() {
         let valid_help_in =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -683,7 +683,6 @@ mod unit {
         assert_eq!(valid_help_in, test::valid_getinfo_annotation());
     }
 
-    #[ignore]
     #[test]
     fn interpret_help_message_late_extrabrackets_input() {
         let valid_help_in =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,6 +212,7 @@ fn bind_idents_labels(
             .trim()
             .splitn(2, ':')
             .collect::<Vec<&str>>()[0]
+            .trim()
             .trim_matches('"');
         let end_map = [(last_ident, inner_value.unwrap())]
             .iter()
@@ -510,7 +511,7 @@ mod unit {
         let mut special_nested_blockchaininfo =
             &mut test::SPECIAL_NESTED_GETBLOCKCHAININFO.chars();
         let annotated = annotate_result(&mut special_nested_blockchaininfo);
-        let expected_result = serde_json::json!({"xxxx":{"name":"String"}});
+        let expected_result = serde_json::json!({"xxxx" :{"name":"String"}});
         assert_eq!(expected_result, annotated);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -764,20 +764,4 @@ mod unit {
         let help_getinfo = interpret_help_message(test::HELP_GETINFO);
         assert_eq!(getinfo_serde_json_value, help_getinfo);
     }
-
-    // ----------------serde_json_value : ignored---------------
-    // TODO may pass after 'scrubbing' function in place
-    // else needs to be retooled
-    #[ignore]
-    #[test]
-    fn serde_json_value_help_getblockchaininfo() {
-        let getblockchaininfo_serde_json_value =
-            test::getblockchaininfo_export();
-        let help_getblockchaininfo =
-            interpret_help_message(test::HELP_GETBLOCKCHAININFO_COMPLETE);
-        assert_eq!(
-            getblockchaininfo_serde_json_value.to_string(),
-            help_getblockchaininfo
-        );
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -724,15 +724,36 @@ mod unit {
             test::HELP_GETBLOCKCHAININFO_COMPLETE
         ));
     }
-    // TODO make expected interpreted Value.
-    #[ignore]
     #[test]
     fn interpret_help_message_getblockchaininfo_complete() {
-        let expected = test::getblockchaininfo_export();
-        assert_eq!(
-            expected,
-            interpret_help_message(test::HELP_GETBLOCKCHAININFO_COMPLETE)
-        );
+        let expected = serde_json::json!({"bestblockhash":"String",
+                                          "blocks":"Decimal",
+                                          "chain":"String",
+                                          "chainwork":"String",
+                                          "commitments":"Decimal",
+                                          "consensus":{"chaintip":"String",
+                                                       "nextblock":"String"},
+                                          "difficulty":"Decimal",
+                                          "estimatedheight":"Decimal",
+                                          "headers":"Decimal",
+                                          "initial_block_download_complete":"bool",
+                                          "size_on_disk":"Decimal",
+                                          "softforks":[{"enforce":{"found":"Decimal",
+                                                                   "required":"Decimal",
+                                                                   "status":"bool",
+                                                                   "window":"Decimal"},
+                                                        "id":"String",
+                                                        "reject":{"found":"Decimal",
+                                                                  "required":"Decimal",
+                                                                  "status":"bool",
+                                                                  "window":"Decimal"},
+                                                        "version":"Decimal"}],
+                                          "upgrades":{"xxxx":{"activationheight":"Decimal",
+                                                              "info":"String",
+                                                              "name":"String",
+                                                              "status":"String"}},
+                                          "verificationprogress":"Decimal"});
+        assert_eq!(expected, interpret_help_message(test::HELP_GETBLOCKCHAININFO_COMPLETE));
     }
 
     // ----------------serde_json_value----------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -690,14 +690,13 @@ mod unit {
         assert_eq!(valid_help_in, test::valid_getinfo_annotation());
     }
 
-    #[ignore]
     #[test]
     fn interpret_help_message_getblockchaininfo_softforks_fragment() {
         let expected_incoming = test::GETBLOCKCHAININFO_SOFTFORK_FRAGMENT;
-        let expected_results = r#"{"softforks":"[{\"enforce\":\"{\\\"found\\\":\\\"Decimal\\\",\\\"required\\\":\\\"Decimal\\\",\\\"status\\\":\\\"bool\\\",\\\"window\\\":\\\"Decimal\\\"},\",\"id\":\"String\",\"reject\":\"{\\\"found\\\":\\\"Decimal\\\",\\\"required\\\":\\\"Decimal\\\",\\\"status\\\":\\\"bool\\\",\\\"window\\\":\\\"Decimal\\\"}\",\"version\":\"Decimal\"}],"}"#;
+        let expected_result = serde_json::json!({"softforks":[{"enforce":{"found":"Decimal","required":"Decimal","status":"bool","window":"Decimal"},"id":"String","reject":{"found":"Decimal","required":"Decimal","status":"bool","window":"Decimal"},"version":"Decimal"}]});
         assert_eq!(
-            format!("{}", interpret_help_message(expected_incoming)),
-            expected_results
+            interpret_help_message(expected_incoming),
+            expected_result
         );
     }
 

--- a/src/utils/test.rs
+++ b/src/utils/test.rs
@@ -39,7 +39,7 @@ Result:
      }, ...
   ],
   "upgrades": {                (object) status of network upgrades
-     "xxxx" : {                (string) branch ID of the upgrade
+     "xxxx": {                (string) branch ID of the upgrade
         "name": "xxxx",        (string) name of upgrade
         "activationheight": xxxxxx,  (numeric) block height of activation
         "status": "xxxx",      (string) status of upgrade

--- a/src/utils/test.rs
+++ b/src/utils/test.rs
@@ -39,7 +39,7 @@ Result:
      }, ...
   ],
   "upgrades": {                (object) status of network upgrades
-     "xxxx": {                (string) branch ID of the upgrade
+     "xxxx" : {                (string) branch ID of the upgrade
         "name": "xxxx",        (string) name of upgrade
         "activationheight": xxxxxx,  (numeric) block height of activation
         "status": "xxxx",      (string) status of upgrade


### PR DESCRIPTION
This PR removes `dbg` and `ignore` statements from the code.

Once it lands several more tests will run!

One outstanding TODO, is to upgrade tests that do _not_ include assert statements.